### PR TITLE
feat: upgrade to new workspace (workspace — requires tweaks)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,41 +10,28 @@ master_revision = "Latest"
 
 [dependencies]
 # Gadget dependencies
-gadget-event-listeners = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["std", "tangle"] }
-gadget-macros = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["tangle", "std"] }
-gadget-crypto = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["default"] }
-gadget-crypto-tangle-pair-signer = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["evm"] }
-gadget-config = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["std"] }
-gadget-logging = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["std"] }
-gadget-runners = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["tangle"] }
-gadget-store-local-database = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["std"] }
-gadget-networking = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["std", "round-based-compat"] }
+blueprint-sdk = { git = "https://github.com/tangle-network/gadget-workspace/", branch = "serial/sdk", features = ["tangle", "p2p", "local-store", "macros", "networking", "round-based-compat"] }
+gadget-macros = { git = "https://github.com/tangle-network/gadget-workspace/", branch = "serial/sdk" }
 color-eyre = { version = "0.6", features = ["tracing-error", "color-spantrace"] }
-tokio = { version = "1.40", default-features = false, features = ["full"] }
 hex = { version = "0.4.3", default-features = false }
 k256 = { version = "0.13.3", default-features = false }
-sp-core = { version = "31.0.0" }
-serde = { version = "1.0.214", features = ["derive"] }
-round-based = { version = "0.3.2", features = ["runtime-tokio", "derive"] }
+serde = { version = "1.0.214", features = ["derive", "rc"] }
+round-based = { version = "0.3.2", features = ["runtime-tokio", "derive", "round-based-derive"] }
 thiserror = "2.0.3"
 itertools = "0.13.0"
 rand = "0.8.5"
 parking_lot = { version = "0.12.3", features = ["serde"]}
 p256k1 = "^5"
-frost-secp256k1-tr = { git = "https://github.com/webb-tools/tangle.git", branch = "main", default-features = false}
+frost-secp256k1-tr = { git = "https://github.com/webb-tools/tangle.git", branch = "main", features = ["std"]}
 
 # MPC specific deps
 wsts = "3.0.0"
 
 [build-dependencies]
-blueprint-metadata = { git = "https://github.com/tangle-network/gadget-workspace/" }
-blueprint-build-utils = { git = "https://github.com/tangle-network/gadget-workspace/" }
+blueprint-sdk = { git = "https://github.com/tangle-network/gadget-workspace/", branch = "serial/sdk",  features = ["build"] }
 
 [dev-dependencies]
-gadget-client-tangle = { git = "https://github.com/tangle-network/gadget-workspace/" }
-gadget-tangle-testing-utils = { git = "https://github.com/tangle-network/gadget-workspace/" }
-gadget-testing-utils = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["tangle"] }
-tempfile = "3.15.0"
+blueprint-sdk = { git = "https://github.com/tangle-network/gadget-workspace/", branch = "serial/sdk", features = ["testing"] }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,37 +6,45 @@ edition = "2021"
 
 [package.metadata.blueprint]
 manager = { Evm = "WstsBlueprint" }
+master_revision = "Latest"
 
 [dependencies]
-gadget-sdk = { git = "https://github.com/tangle-network/gadget/", features = ["std"] }
-#gadget-sdk = { path = "../gadget/sdk", features = ["std"] }
+# Gadget dependencies
+gadget-event-listeners = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["std", "tangle"] }
+gadget-macros = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["tangle", "std"] }
+gadget-crypto = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["default"] }
+gadget-crypto-tangle-pair-signer = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["evm"] }
+gadget-config = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["std"] }
+gadget-logging = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["std"] }
+gadget-runners = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["tangle"] }
+gadget-store-local-database = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["std"] }
+gadget-networking = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["std", "round-based-compat"] }
 color-eyre = { version = "0.6", features = ["tracing-error", "color-spantrace"] }
 tokio = { version = "1.40", default-features = false, features = ["full"] }
 hex = { version = "0.4.3", default-features = false }
 k256 = { version = "0.13.3", default-features = false }
-bincode = "1.3.3"
-sp-core = { version = "31.0.0", default-features = false }
-rand_chacha = "0.3.1"
+sp-core = { version = "31.0.0" }
 serde = { version = "1.0.214", features = ["derive"] }
-round-based = { version = "0.3.2", features = ["runtime-tokio"] }
-tracing-subscriber = "0.3.18"
+round-based = { version = "0.3.2", features = ["runtime-tokio", "derive"] }
 thiserror = "2.0.3"
 itertools = "0.13.0"
 rand = "0.8.5"
 parking_lot = { version = "0.12.3", features = ["serde"]}
-p256k1 = "5.4"
-frost-taproot = { git = "https://github.com/webb-tools/tangle.git", branch = "main", default-features = false}
+p256k1 = "^5"
+frost-secp256k1-tr = { git = "https://github.com/webb-tools/tangle.git", branch = "main", default-features = false}
 
 # MPC specific deps
 wsts = "3.0.0"
 
 [build-dependencies]
-blueprint-metadata = { git = "https://github.com/tangle-network/gadget/" }
-blueprint-build-utils = { git = "https://github.com/tangle-network/gadget/" }
+blueprint-metadata = { git = "https://github.com/tangle-network/gadget-workspace/" }
+blueprint-build-utils = { git = "https://github.com/tangle-network/gadget-workspace/" }
 
 [dev-dependencies]
-blueprint-test-utils = { git = "https://github.com/tangle-network/gadget/" }
-cargo-tangle = { git = "https://github.com/tangle-network/gadget/" }
+gadget-client-tangle = { git = "https://github.com/tangle-network/gadget-workspace/" }
+gadget-tangle-testing-utils = { git = "https://github.com/tangle-network/gadget-workspace/" }
+gadget-testing-utils = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["tangle"] }
+tempfile = "3.15.0"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ master_revision = "Latest"
 
 [dependencies]
 # Gadget dependencies
-blueprint-sdk = { git = "https://github.com/tangle-network/gadget-workspace/", branch = "serial/sdk", features = ["tangle", "p2p", "local-store", "macros", "networking", "round-based-compat"] }
-gadget-macros = { git = "https://github.com/tangle-network/gadget-workspace/", branch = "serial/sdk" }
+blueprint-sdk = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["tangle", "local-store", "macros", "networking", "round-based-compat"] }
+gadget-macros = { git = "https://github.com/tangle-network/gadget-workspace/" }
 color-eyre = { version = "0.6", features = ["tracing-error", "color-spantrace"] }
 hex = { version = "0.4.3", default-features = false }
 k256 = { version = "0.13.3", default-features = false }
@@ -28,10 +28,10 @@ frost-secp256k1-tr = { git = "https://github.com/webb-tools/tangle.git", branch 
 wsts = "3.0.0"
 
 [build-dependencies]
-blueprint-sdk = { git = "https://github.com/tangle-network/gadget-workspace/", branch = "serial/sdk",  features = ["build"] }
+blueprint-sdk = { git = "https://github.com/tangle-network/gadget-workspace/",   features = ["build"] }
 
 [dev-dependencies]
-blueprint-sdk = { git = "https://github.com/tangle-network/gadget-workspace/", branch = "serial/sdk", features = ["testing"] }
+blueprint-sdk = { git = "https://github.com/tangle-network/gadget-workspace/",  features = ["testing"] }
 
 [features]
 default = ["std"]

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,11 @@
+use blueprint_sdk::build::blueprint_metadata;
+
 fn main() {
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=src/main.rs");
     blueprint_metadata::generate_json();
 
     let contract_dirs: Vec<&str> = vec!["./contracts"];
-    blueprint_build_utils::soldeer_update();
-    blueprint_build_utils::build_contracts(contract_dirs);
+    blueprint_sdk::build::utils::soldeer_update();
+    blueprint_sdk::build::utils::build_contracts(contract_dirs);
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,14 +1,13 @@
+use crate::keygen_state_machine::WstsState;
 use color_eyre::eyre;
-use gadget_sdk as sdk;
-use gadget_sdk::ext::subxt::tx::Signer;
-use gadget_sdk::network::NetworkMultiplexer;
-use gadget_sdk::store::LocalDatabase;
-use gadget_sdk::subxt_core::ext::sp_core::ecdsa;
-use sdk::contexts::{KeystoreContext, MPCContext, ServicesContext, TangleClientContext};
+use gadget_config::StdGadgetConfiguration;
+use gadget_crypto_tangle_pair_signer::sp_core::ecdsa;
+use gadget_macros::contexts::{KeystoreContext, P2pContext, ServicesContext, TangleClientContext};
+use gadget_networking::networking::NetworkMultiplexer;
+use gadget_networking::setup::start_p2p_network;
+use gadget_store_local_database::LocalDatabase;
 use std::path::PathBuf;
 use std::sync::Arc;
-
-use crate::keygen_state_machine::WstsState;
 
 /// The network protocol version for the WSTS service
 const NETWORK_PROTOCOL: &str = "/wsts/frost/1.0.0";
@@ -16,10 +15,10 @@ const NETWORK_PROTOCOL: &str = "/wsts/frost/1.0.0";
 /// WSTS Service Context that holds all the necessary context for the service
 /// to run. This structure implements various traits for keystore, client, and service
 /// functionality.
-#[derive(Clone, KeystoreContext, TangleClientContext, ServicesContext, MPCContext)]
+#[derive(Clone, KeystoreContext, TangleClientContext, ServicesContext, P2pContext)]
 pub struct WstsContext {
     #[config]
-    pub config: sdk::config::StdGadgetConfiguration,
+    pub config: StdGadgetConfiguration,
     #[call_id]
     pub call_id: Option<u64>,
     pub network_backend: Arc<NetworkMultiplexer>,
@@ -35,13 +34,13 @@ impl WstsContext {
     /// Returns an error if:
     /// - Network initialization fails
     /// - Configuration is invalid
-    pub fn new(config: sdk::config::StdGadgetConfiguration) -> eyre::Result<Self> {
+    pub fn new(config: StdGadgetConfiguration) -> eyre::Result<Self> {
         let network_config = config
             .libp2p_network_config(NETWORK_PROTOCOL)
             .map_err(|err| eyre::eyre!("Failed to create network configuration: {err}"))?;
 
         let identity = network_config.ecdsa_key.clone();
-        let gossip_handle = sdk::network::setup::start_p2p_network(network_config)
+        let gossip_handle = start_p2p_network(network_config)
             .map_err(|err| eyre::eyre!("Failed to start the P2P network: {err}"))?;
 
         let keystore_dir = PathBuf::from(config.keystore_uri.clone()).join("wsts.json");

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,5 @@
 use crate::keygen_state_machine::WstsState;
 use blueprint_sdk::config::StdGadgetConfiguration;
-use blueprint_sdk::macros as gadget_macros;
 use blueprint_sdk::macros::contexts::{
     KeystoreContext, P2pContext, ServicesContext, TangleClientContext,
 };

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,11 +1,14 @@
 use crate::keygen_state_machine::WstsState;
+use blueprint_sdk::config::StdGadgetConfiguration;
+use blueprint_sdk::macros as gadget_macros;
+use blueprint_sdk::macros::contexts::{
+    KeystoreContext, P2pContext, ServicesContext, TangleClientContext,
+};
+use blueprint_sdk::networking::networking::NetworkMultiplexer;
+use blueprint_sdk::networking::setup::start_p2p_network;
+use blueprint_sdk::networking::GossipMsgKeyPair;
+use blueprint_sdk::stores::local_database::LocalDatabase;
 use color_eyre::eyre;
-use gadget_config::StdGadgetConfiguration;
-use gadget_crypto_tangle_pair_signer::sp_core::ecdsa;
-use gadget_macros::contexts::{KeystoreContext, P2pContext, ServicesContext, TangleClientContext};
-use gadget_networking::networking::NetworkMultiplexer;
-use gadget_networking::setup::start_p2p_network;
-use gadget_store_local_database::LocalDatabase;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -23,7 +26,7 @@ pub struct WstsContext {
     pub call_id: Option<u64>,
     pub network_backend: Arc<NetworkMultiplexer>,
     pub store: Arc<LocalDatabase<WstsState>>,
-    pub identity: ecdsa::Pair,
+    pub identity: GossipMsgKeyPair,
 }
 
 // Core context management implementation
@@ -39,7 +42,7 @@ impl WstsContext {
             .libp2p_network_config(NETWORK_PROTOCOL)
             .map_err(|err| eyre::eyre!("Failed to create network configuration: {err}"))?;
 
-        let identity = network_config.ecdsa_key.clone();
+        let identity = network_config.secret_key.clone();
         let gossip_handle = start_p2p_network(network_config)
             .map_err(|err| eyre::eyre!("Failed to start the P2P network: {err}"))?;
 

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -7,11 +7,11 @@ use blueprint_sdk::event_listeners::tangle::events::TangleEventListener;
 use blueprint_sdk::event_listeners::tangle::services::{
     services_post_processor, services_pre_processor,
 };
+use blueprint_sdk::job;
 use blueprint_sdk::logging::info;
 use blueprint_sdk::macros::ext::contexts::tangle::TangleClientContext;
 use blueprint_sdk::networking::round_based_compat::NetworkDeliveryWrapper;
 use blueprint_sdk::tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled;
-use blueprint_sdk::*;
 use gadget_macros::ext::clients::GadgetServicesClient;
 use std::collections::BTreeMap;
 use wsts::v2::Party;

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -1,17 +1,15 @@
 use crate::keygen_state_machine;
 use crate::utils::validate_parameters;
 use crate::{context::WstsContext, keygen_state_machine::WstsState};
-use gadget_sdk::contexts::MPCContext;
-use gadget_sdk::{
-    event_listener::tangle::{
-        jobs::{services_post_processor, services_pre_processor},
-        TangleEventListener,
-    },
-    job,
-    network::round_based_compat::NetworkDeliveryWrapper,
-    tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled,
-    Error as GadgetError,
-};
+use gadget_crypto::k256::K256VerifyingKey;
+use gadget_crypto::KeyEncoding;
+use gadget_event_listeners::tangle::events::TangleEventListener;
+use gadget_event_listeners::tangle::services::{services_post_processor, services_pre_processor};
+use gadget_macros::ext::clients::GadgetServicesClient;
+use gadget_macros::ext::contexts::tangle::TangleClientContext;
+use gadget_macros::ext::tangle::tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled;
+use gadget_macros::job;
+use gadget_networking::round_based_compat::NetworkDeliveryWrapper;
 use sp_core::ecdsa::Public;
 use std::collections::BTreeMap;
 use wsts::v2::Party;
@@ -40,26 +38,32 @@ use wsts::v2::Party;
 /// - Failed to get party information
 /// - MPC protocol execution failed
 /// - Serialization of results failed
-pub async fn keygen(t: u16, context: WstsContext) -> Result<Vec<u8>, GadgetError> {
+pub async fn keygen(t: u16, context: WstsContext) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     // Get configuration and compute deterministic values
-    let blueprint_id = context
+    let client = context.tangle_client().await?;
+    let blueprint_id = client
         .blueprint_id()
-        .map_err(|e| KeygenError::ContextError(e.to_string()))?;
-    let call_id = context
-        .current_call_id()
         .await
         .map_err(|e| KeygenError::ContextError(e.to_string()))?;
+    let call_id = context
+        .call_id
+        .ok_or_else(|| KeygenError::ContextError("Call_id not set".into()))?;
 
     // Setup party information
-    let (i, operators) = context
+    let (i, operators) = client
         .get_party_index_and_operators()
         .await
         .map_err(|e| KeygenError::ContextError(e.to_string()))?;
 
-    let parties: BTreeMap<u16, Public> = operators
+    let parties: BTreeMap<u16, _> = operators
         .into_iter()
         .enumerate()
-        .map(|(j, (_, ecdsa))| (j as u16, ecdsa))
+        .map(|(j, (_, ecdsa))| {
+            (
+                j as u16,
+                K256VerifyingKey::from_bytes(&ecdsa.0).expect("33 byte compressed ECDSA key"),
+            )
+        })
         .collect();
 
     let n = parties.len() as u16;
@@ -67,9 +71,9 @@ pub async fn keygen(t: u16, context: WstsContext) -> Result<Vec<u8>, GadgetError
     let k = n;
 
     let (meta_hash, deterministic_hash) =
-        crate::compute_deterministic_hashes(n, blueprint_id, call_id, KEYGEN_SALT);
+        crate::compute_execution_hashes(n, blueprint_id, call_id, KEYGEN_SALT);
 
-    gadget_sdk::info!(
+    gadget_logging::info!(
         "Starting WSTS Keygen for party {i}, n={n}, eid={}",
         hex::encode(deterministic_hash)
     );
@@ -83,7 +87,7 @@ pub async fn keygen(t: u16, context: WstsContext) -> Result<Vec<u8>, GadgetError
 
     let state = protocol(n as _, i as _, k as _, t as _, network).await?;
 
-    gadget_sdk::info!(
+    gadget_logging::info!(
         "Ending WSTS Keygen for party {i}, n={n}, eid={}",
         hex::encode(deterministic_hash)
     );
@@ -113,12 +117,9 @@ pub enum KeygenError {
 
     #[error("Delivery error: {0}")]
     DeliveryError(String),
-}
 
-impl From<KeygenError> for GadgetError {
-    fn from(err: KeygenError) -> Self {
-        GadgetError::Other(err.to_string())
-    }
+    #[error("Setup error: {0}")]
+    SetupError(String),
 }
 
 async fn protocol(
@@ -127,7 +128,7 @@ async fn protocol(
     k: u32,
     t: u32,
     network: NetworkDeliveryWrapper<keygen_state_machine::Msg>,
-) -> Result<WstsState, GadgetError> {
+) -> Result<WstsState, KeygenError> {
     validate_parameters(n, k, t)?;
     let mut rng = rand::rngs::OsRng;
     let key_ids = crate::utils::generate_party_key_ids(n, k);
@@ -138,9 +139,8 @@ async fn protocol(
     let network = round_based::party::MpcParty::connected(network);
     let mut party = Party::new(party_id, our_key_ids, n, k, t, &mut rng);
     let state =
-        crate::keygen_state_machine::wsts_protocol(network, &mut party, n as usize, &mut rng)
-            .await?;
-    gadget_sdk::info!(
+        keygen_state_machine::wsts_protocol(network, &mut party, n as usize, &mut rng).await?;
+    gadget_logging::info!(
         "Combined public key: {:?}",
         state.party.lock().as_ref().unwrap().group_key
     );

--- a/src/keygen_state_machine.rs
+++ b/src/keygen_state_machine.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::keygen::KeygenError;
-use frost_taproot::VerifyingKey;
+use frost_secp256k1_tr::VerifyingKey;
 use itertools::Itertools;
 use round_based::SinkExt;
 use std::sync::Arc;
@@ -99,7 +99,7 @@ where
         state.poly_commitments.insert(party_id, msg.poly_commitment);
     }
 
-    gadget_sdk::trace!(
+    gadget_logging::trace!(
         "Received shares: {:?}",
         state.shares.keys().collect::<Vec<_>>()
     );
@@ -135,14 +135,14 @@ where
     // Convert the WSTS group key into a FROST-compatible format
     let group_point = party.group_key;
     let compressed_group_point = group_point.compress();
-    let verifying_key = VerifyingKey::deserialize(compressed_group_point.data).map_err(|e| {
+    let verifying_key = VerifyingKey::deserialize(&compressed_group_point.data).map_err(|e| {
         KeygenError::MpcError(format!("Failed to convert group key to VerifyingKey: {e}"))
     })?;
     let public_key_frost_format = verifying_key.serialize().as_ref().to_vec();
     state.public_key_frost_format = public_key_frost_format;
     state.party = Arc::new(parking_lot::Mutex::new(Some(party)));
 
-    gadget_sdk::info!("Keygen finished computing secret");
+    gadget_logging::info!("Keygen finished computing secret");
 
     Ok(state)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod keygen;
 pub(crate) mod keygen_state_machine;
 pub mod signing;
 pub(crate) mod signing_state_machine;
-pub(crate) mod utils;
+pub mod utils;
 
 pub use blueprint_sdk::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ pub mod signing;
 pub(crate) mod signing_state_machine;
 pub(crate) mod utils;
 
+pub use blueprint_sdk::*;
+
 const META_SALT: &str = "wsts-protocol";
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,23 +6,39 @@ pub(crate) mod signing_state_machine;
 pub(crate) mod utils;
 
 const META_SALT: &str = "wsts-protocol";
+
+#[macro_export]
+macro_rules! compute_sha256_hash {
+    ($($data:expr),*) => {
+        {
+            use k256::sha2::{Digest, Sha256};
+            let mut hasher = Sha256::default();
+            $(hasher.update($data);)*
+            let result = hasher.finalize();
+            let mut hash = [0u8; 32];
+            hash.copy_from_slice(result.as_slice());
+            hash
+        }
+    };
+}
+
 /// Helper function to compute deterministic hashes for the WSTS processes.
 /// Note: for signing, the "call_id" should be the call_id of the preceeding
 /// keygen job
-pub fn compute_deterministic_hashes(
+pub fn compute_execution_hashes(
     n: u16,
     blueprint_id: u64,
     call_id: u64,
     salt: &'static str,
 ) -> ([u8; 32], [u8; 32]) {
-    let meta_hash = gadget_sdk::compute_sha256_hash!(
+    let interexecution_hash = compute_sha256_hash!(
         n.to_be_bytes(),
         blueprint_id.to_be_bytes(),
         call_id.to_be_bytes(),
         META_SALT
     );
 
-    let deterministic_hash = gadget_sdk::compute_sha256_hash!(meta_hash.as_ref(), salt);
+    let intraexecution_hash = compute_sha256_hash!(interexecution_hash.as_ref(), salt);
 
-    (meta_hash, deterministic_hash)
+    (interexecution_hash, intraexecution_hash)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,18 @@
+use blueprint_sdk::logging::info;
+use blueprint_sdk::macros;
+use blueprint_sdk::runners::core::runner::BlueprintRunner;
+use blueprint_sdk::runners::tangle::tangle::TangleConfig;
 use color_eyre::Result;
-use gadget_logging::info;
-use gadget_runners::core::runner::BlueprintRunner;
 use wsts_blueprint::context::WstsContext;
+use wsts_blueprint::crypto::KeyEncoding;
 
-#[gadget_macros::main(env)]
+#[macros::main(env)]
 async fn main() {
     let context = WstsContext::new(env.clone())?;
 
     info!(
         "Starting the Blueprint Runner for {} ...",
-        hex::encode(context.identity.public().as_ref())
+        hex::encode(context.identity.public().to_bytes())
     );
 
     info!("~~~ Executing the WSTS blueprint ~~~");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,9 @@
 use color_eyre::Result;
-use gadget_sdk::info;
-use gadget_sdk::runners::tangle::TangleConfig;
-use gadget_sdk::runners::BlueprintRunner;
-use gadget_sdk::subxt::ext::sp_core::Pair;
+use gadget_logging::info;
+use gadget_runners::core::runner::BlueprintRunner;
 use wsts_blueprint::context::WstsContext;
 
-#[gadget_sdk::main(env)]
+#[gadget_macros::main(env)]
 async fn main() {
     let context = WstsContext::new(env.clone())?;
 

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -6,11 +6,10 @@ use blueprint_sdk::event_listeners::tangle::services::{
     services_post_processor, services_pre_processor,
 };
 use blueprint_sdk::logging::info;
-use blueprint_sdk::macros as gadget_macros;
 use blueprint_sdk::macros::ext::contexts::tangle::TangleClientContext;
 use blueprint_sdk::networking::round_based_compat::NetworkDeliveryWrapper;
 use blueprint_sdk::tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled;
-use blueprint_sdk::*;
+use blueprint_sdk::{job, macros as gadget_macros};
 use gadget_macros::ext::clients::GadgetServicesClient;
 use std::collections::BTreeMap;
 

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -1,13 +1,17 @@
 use crate::context::WstsContext;
-use gadget_crypto::k256::K256VerifyingKey;
-use gadget_crypto::KeyEncoding;
-use gadget_event_listeners::tangle::events::TangleEventListener;
-use gadget_event_listeners::tangle::services::{services_post_processor, services_pre_processor};
+use blueprint_sdk::crypto::k256::K256VerifyingKey;
+use blueprint_sdk::crypto::KeyEncoding;
+use blueprint_sdk::event_listeners::tangle::events::TangleEventListener;
+use blueprint_sdk::event_listeners::tangle::services::{
+    services_post_processor, services_pre_processor,
+};
+use blueprint_sdk::logging::info;
+use blueprint_sdk::macros as gadget_macros;
+use blueprint_sdk::macros::ext::contexts::tangle::TangleClientContext;
+use blueprint_sdk::networking::round_based_compat::NetworkDeliveryWrapper;
+use blueprint_sdk::tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled;
+use blueprint_sdk::*;
 use gadget_macros::ext::clients::GadgetServicesClient;
-use gadget_macros::ext::contexts::tangle::TangleClientContext;
-use gadget_macros::ext::tangle::tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled;
-use gadget_macros::job;
-use gadget_networking::round_based_compat::NetworkDeliveryWrapper;
 use std::collections::BTreeMap;
 
 /// Configuration constants for the WSTS signing process
@@ -84,7 +88,7 @@ pub async fn sign(
         .get(&store_key)
         .ok_or_else(|| SigningError::ContextError("Key entry not found".to_string()))?;
 
-    gadget_logging::info!(
+    info!(
         "Starting WSTS Signing for party {i}, n={n}, eid={}",
         hex::encode(deterministic_hash)
     );

--- a/src/signing_state_machine.rs
+++ b/src/signing_state_machine.rs
@@ -263,9 +263,8 @@ where
     let frost_signature = frost_secp256k1_tr::Signature::deserialize(&signature_bytes)
         .map_err(|_| SigningError::InvalidFrostSignature)?;
 
-    let frost_verifying_key =
-        VerifyingKey::deserialize(state.public_key_frost_format.clone().try_into().unwrap())
-            .map_err(|_| SigningError::InvalidFrostVerifyingKey)?;
+    let frost_verifying_key = VerifyingKey::deserialize(&state.public_key_frost_format)
+        .map_err(|_| SigningError::InvalidFrostVerifyingKey)?;
 
     frost_verifying_key
         .verify(&message, &frost_signature)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,21 +1,16 @@
-use gadget_sdk::Error;
-pub fn validate_parameters(n: u32, k: u32, t: u32) -> Result<(), Error> {
+use crate::keygen::KeygenError;
+
+pub fn validate_parameters(n: u32, k: u32, t: u32) -> Result<(), KeygenError> {
     if k % n != 0 {
-        return Err(Error::Job {
-            reason: format!("K({k} % N({n} != 0"),
-        });
+        return Err(KeygenError::SetupError(format!("k({k}) % n({n}) != 0")));
     }
 
     if k == 0 {
-        return Err(Error::Job {
-            reason: "K == 0".to_string(),
-        });
+        return Err(KeygenError::SetupError(format!("k({k}) == 0")));
     }
 
     if n <= t {
-        return Err(Error::Job {
-            reason: "N <= T".to_string(),
-        });
+        return Err(KeygenError::SetupError(format!("n({n}) <= t({t})")));
     }
 
     Ok(())

--- a/tests/wsts.rs
+++ b/tests/wsts.rs
@@ -1,147 +1,77 @@
 #[cfg(test)]
 mod e2e {
-    use blueprint_sdk::logging::{info, setup_log};
-    use blueprint_sdk::tangle_subxt::tangle_testnet_runtime::api::services::calls::types::call::Job;
-    use blueprint_sdk::testing::tangle::InputValue;
-    use blueprint_sdk::testing::tangle::node::NodeConfig;
-    use blueprint_sdk::testing::tangle::node::transactions::{get_next_call_id, submit_job, wait_for_completion_of_tangle_job};
+    use blueprint_sdk::logging::setup_log;
+    use blueprint_sdk::testing::tangle::{InputValue, TangleTestHarness};
     use blueprint_sdk::testing::tempfile;
+    use blueprint_sdk::testing::utils::harness::TestHarness;
+    use blueprint_sdk::testing::utils::runner::TestEnv;
     use blueprint_sdk::tokio;
+    use wsts_blueprint::context::WstsContext;
     use wsts_blueprint::keygen::KEYGEN_JOB_ID;
     use wsts_blueprint::signing::SIGN_JOB_ID;
     use wsts_blueprint::tangle_subxt::tangle_testnet_runtime::api::runtime_types::bounded_collections::bounded_vec::BoundedVec;
 
-    const N: usize = 3;
     const T: usize = 2;
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_blueprint() {
+    async fn test_blueprint() -> Result<(), Box<dyn std::error::Error>> {
         setup_log();
 
-        let tmp_dir = tempfile::TempDir::new().unwrap();
-        let tmp_dir_path = format!("{}", tmp_dir.path().display());
+        // Initialize test harness (node, keys, deployment)
+        let temp_dir = tempfile::TempDir::new()?;
+        let harness = TangleTestHarness::setup(temp_dir).await?;
+        let env = harness.env().clone();
 
-        new_test_ext_blueprint_manager::<N, 1, String, _, _>(
-            tmp_dir_path,
-            run_test_blueprint_manager,
-            NodeConfig::new(false),
-        )
-            .await
-            .execute_with_async(|client, handles, blueprint, _| async move {
-                let keypair = handles[0].sr25519_id().clone();
-                let service = &blueprint.services[KEYGEN_JOB_ID as usize];
+        // Create blueprint-specific context
+        let blueprint_ctx = WstsContext::new(env.clone())?;
 
-                let service_id = service.id;
-                info!(
-                    "Submitting KEYGEN job {KEYGEN_JOB_ID} with service ID {service_id}",
-                );
+        // Initialize event handler
+        let keygen_handler =
+            wsts_blueprint::keygen::KeygenEventHandler::new(&env.clone(), blueprint_ctx.clone())
+                .await?;
 
-                let job_args = vec![(InputValue::Uint16(T as u16))];
-                let call_id = get_next_call_id(client)
-                    .await
-                    .expect("Failed to get next job id")
-                    .saturating_sub(1);
-                let job = submit_job(
-                    client,
-                    &keypair,
-                    service_id,
-                    Job::from(KEYGEN_JOB_ID),
-                    job_args,
-                    call_id,
-                )
-                    .await
-                    .expect("Failed to submit job");
+        let signing_handler =
+            wsts_blueprint::signing::SignEventHandler::new(&env.clone(), blueprint_ctx).await?;
 
-                let keygen_call_id = job.call_id;
+        // Setup service
+        let (mut test_env, service_id) = harness.setup_services().await?;
+        test_env.add_job(keygen_handler);
+        test_env.add_job(signing_handler);
 
-                info!(
-                    "Submitted KEYGEN job {} with service ID {service_id} has call id {keygen_call_id}",
-                    KEYGEN_JOB_ID
-                );
+        tokio::spawn(async move {
+            test_env.run_runner().await.unwrap();
+        });
 
-                let job_results = wait_for_completion_of_tangle_job(client, service_id, keygen_call_id, T)
-                    .await
-                    .expect("Failed to wait for job completion");
+        // Execute job and verify result
+        let keygen_result = harness
+            .execute_job(
+                service_id,
+                KEYGEN_JOB_ID,
+                vec![(InputValue::Uint16(T as u16))],
+                vec![],
+            )
+            .await?;
 
-                assert_eq!(job_results.service_id, service_id);
-                assert_eq!(job_results.call_id, keygen_call_id);
+        assert_eq!(keygen_result.service_id, service_id);
 
-                let expected_outputs = vec![];
-                if !expected_outputs.is_empty() {
-                    assert_eq!(
-                        job_results.result.len(),
-                        expected_outputs.len(),
-                        "Number of keygen outputs doesn't match expected"
-                    );
-
-                    for (result, expected) in job_results
-                        .result
-                        .into_iter()
-                        .zip(expected_outputs.into_iter())
-                    {
-                        assert_eq!(result, expected);
-                    }
-                } else {
-                    info!("No expected outputs specified, skipping keygen verification");
-                }
-
-                info!("Keygen job completed successfully! Moving on to signing ...");
-
-                let service = &blueprint.services[0];
-                let service_id = service.id;
-                info!(
-                    "Submitting SIGNING job {} with service ID {service_id}",
-                    SIGN_JOB_ID
-                );
-
-                let job_args = vec![
-                    InputValue::Uint64(keygen_call_id),
+        let results = harness
+            .execute_job(
+                service_id,
+                SIGN_JOB_ID,
+                vec![
+                    InputValue::Uint64(keygen_result.call_id),
                     InputValue::List(BoundedVec(vec![
                         InputValue::Uint8(1),
                         InputValue::Uint8(2),
                         InputValue::Uint8(3),
                     ])),
-                ];
+                ],
+                vec![],
+            )
+            .await?;
 
-                let job = submit_job(
-                    client,
-                    &keypair,
-                    service_id,
-                    Job::from(SIGN_JOB_ID),
-                    job_args,
-                    call_id + 1,
-                )
-                    .await
-                    .expect("Failed to submit job");
+        assert_eq!(results.service_id, service_id);
 
-                let signing_call_id = job.call_id;
-                info!(
-            "Submitted SIGNING job {SIGN_JOB_ID} with service ID {service_id} has call id {signing_call_id}",
-        );
-
-                let job_results = wait_for_completion_of_tangle_job(client, service_id, signing_call_id, T)
-                    .await
-                    .expect("Failed to wait for job completion");
-
-                let expected_outputs = vec![];
-                if !expected_outputs.is_empty() {
-                    assert_eq!(
-                        job_results.result.len(),
-                        expected_outputs.len(),
-                        "Number of signing outputs doesn't match expected"
-                    );
-
-                    for (result, expected) in job_results
-                        .result
-                        .into_iter()
-                        .zip(expected_outputs.into_iter())
-                    {
-                        assert_eq!(result, expected);
-                    }
-                } else {
-                    info!("No expected outputs specified, skipping signing verification");
-                }
-            })
-            .await
+        Ok(())
     }
 }

--- a/tests/wsts.rs
+++ b/tests/wsts.rs
@@ -1,11 +1,10 @@
 #[cfg(test)]
 mod e2e {
-    use ::blueprint_test_utils::test_ext::new_test_ext_blueprint_manager;
-    pub use ::blueprint_test_utils::{
-        run_test_blueprint_manager, setup_log, submit_job, wait_for_completion_of_tangle_job, Job,
-    };
-    use blueprint_test_utils::tangle::NodeConfig;
-    use blueprint_test_utils::*;
+    use gadget_logging::setup_log;
+    use gadget_macros::ext::blueprint_serde::{BoundedVec, Field as InputValue};
+    use gadget_macros::ext::tangle::tangle_subxt::tangle_testnet_runtime::api::services::calls::types::call::Job;
+    use gadget_tangle_testing_utils::node::transactions::{get_next_call_id, submit_job, wait_for_completion_of_tangle_job};
+    use gadget_testing_utils::tangle::node::NodeConfig;
     use wsts_blueprint::keygen::KEYGEN_JOB_ID;
     use wsts_blueprint::signing::SIGN_JOB_ID;
 
@@ -16,7 +15,7 @@ mod e2e {
     async fn test_blueprint() {
         setup_log();
 
-        let tmp_dir = ::blueprint_test_utils::tempfile::TempDir::new().unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
         let tmp_dir_path = format!("{}", tmp_dir.path().display());
 
         new_test_ext_blueprint_manager::<N, 1, String, _, _>(
@@ -30,7 +29,7 @@ mod e2e {
                 let service = &blueprint.services[KEYGEN_JOB_ID as usize];
 
                 let service_id = service.id;
-                gadget_sdk::info!(
+                gadget_logging::info!(
             "Submitting KEYGEN job {KEYGEN_JOB_ID} with service ID {service_id}",
         );
 
@@ -52,7 +51,7 @@ mod e2e {
 
                 let keygen_call_id = job.call_id;
 
-                gadget_sdk::info!(
+                gadget_logging::info!(
             "Submitted KEYGEN job {} with service ID {service_id} has call id {keygen_call_id}",
             KEYGEN_JOB_ID
         );
@@ -80,14 +79,14 @@ mod e2e {
                         assert_eq!(result, expected);
                     }
                 } else {
-                    gadget_sdk::info!("No expected outputs specified, skipping keygen verification");
+                    gadget_logging::info!("No expected outputs specified, skipping keygen verification");
                 }
 
-                gadget_sdk::info!("Keygen job completed successfully! Moving on to signing ...");
+                gadget_logging::info!("Keygen job completed successfully! Moving on to signing ...");
 
                 let service = &blueprint.services[0];
                 let service_id = service.id;
-                gadget_sdk::info!(
+                gadget_logging::info!(
                     "Submitting SIGNING job {} with service ID {service_id}",
                     SIGN_JOB_ID
                 );
@@ -113,7 +112,7 @@ mod e2e {
                     .expect("Failed to submit job");
 
                 let signing_call_id = job.call_id;
-                gadget_sdk::info!(
+                gadget_logging::info!(
             "Submitted SIGNING job {SIGN_JOB_ID} with service ID {service_id} has call id {signing_call_id}",
         );
 
@@ -137,7 +136,7 @@ mod e2e {
                         assert_eq!(result, expected);
                     }
                 } else {
-                    gadget_sdk::info!("No expected outputs specified, skipping signing verification");
+                    gadget_logging::info!("No expected outputs specified, skipping signing verification");
                 }
             })
             .await

--- a/tests/wsts.rs
+++ b/tests/wsts.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod e2e {
     use blueprint_sdk::logging::setup_log;
-    use blueprint_sdk::testing::tangle::{InputValue, TangleTestHarness};
+    use blueprint_sdk::testing::utils::tangle::{InputValue, TangleTestHarness};
     use blueprint_sdk::testing::tempfile;
     use blueprint_sdk::testing::utils::harness::TestHarness;
     use blueprint_sdk::testing::utils::runner::TestEnv;

--- a/tests/wsts.rs
+++ b/tests/wsts.rs
@@ -1,12 +1,15 @@
 #[cfg(test)]
 mod e2e {
-    use gadget_logging::setup_log;
-    use gadget_macros::ext::blueprint_serde::{BoundedVec, Field as InputValue};
-    use gadget_macros::ext::tangle::tangle_subxt::tangle_testnet_runtime::api::services::calls::types::call::Job;
-    use gadget_tangle_testing_utils::node::transactions::{get_next_call_id, submit_job, wait_for_completion_of_tangle_job};
-    use gadget_testing_utils::tangle::node::NodeConfig;
+    use blueprint_sdk::logging::{info, setup_log};
+    use blueprint_sdk::tangle_subxt::tangle_testnet_runtime::api::services::calls::types::call::Job;
+    use blueprint_sdk::testing::tangle::InputValue;
+    use blueprint_sdk::testing::tangle::node::NodeConfig;
+    use blueprint_sdk::testing::tangle::node::transactions::{get_next_call_id, submit_job, wait_for_completion_of_tangle_job};
+    use blueprint_sdk::testing::tempfile;
+    use blueprint_sdk::tokio;
     use wsts_blueprint::keygen::KEYGEN_JOB_ID;
     use wsts_blueprint::signing::SIGN_JOB_ID;
+    use wsts_blueprint::tangle_subxt::tangle_testnet_runtime::api::runtime_types::bounded_collections::bounded_vec::BoundedVec;
 
     const N: usize = 3;
     const T: usize = 2;
@@ -29,9 +32,9 @@ mod e2e {
                 let service = &blueprint.services[KEYGEN_JOB_ID as usize];
 
                 let service_id = service.id;
-                gadget_logging::info!(
-            "Submitting KEYGEN job {KEYGEN_JOB_ID} with service ID {service_id}",
-        );
+                info!(
+                    "Submitting KEYGEN job {KEYGEN_JOB_ID} with service ID {service_id}",
+                );
 
                 let job_args = vec![(InputValue::Uint16(T as u16))];
                 let call_id = get_next_call_id(client)
@@ -51,10 +54,10 @@ mod e2e {
 
                 let keygen_call_id = job.call_id;
 
-                gadget_logging::info!(
-            "Submitted KEYGEN job {} with service ID {service_id} has call id {keygen_call_id}",
-            KEYGEN_JOB_ID
-        );
+                info!(
+                    "Submitted KEYGEN job {} with service ID {service_id} has call id {keygen_call_id}",
+                    KEYGEN_JOB_ID
+                );
 
                 let job_results = wait_for_completion_of_tangle_job(client, service_id, keygen_call_id, T)
                     .await
@@ -79,14 +82,14 @@ mod e2e {
                         assert_eq!(result, expected);
                     }
                 } else {
-                    gadget_logging::info!("No expected outputs specified, skipping keygen verification");
+                    info!("No expected outputs specified, skipping keygen verification");
                 }
 
-                gadget_logging::info!("Keygen job completed successfully! Moving on to signing ...");
+                info!("Keygen job completed successfully! Moving on to signing ...");
 
                 let service = &blueprint.services[0];
                 let service_id = service.id;
-                gadget_logging::info!(
+                info!(
                     "Submitting SIGNING job {} with service ID {service_id}",
                     SIGN_JOB_ID
                 );
@@ -112,7 +115,7 @@ mod e2e {
                     .expect("Failed to submit job");
 
                 let signing_call_id = job.call_id;
-                gadget_logging::info!(
+                info!(
             "Submitted SIGNING job {SIGN_JOB_ID} with service ID {service_id} has call id {signing_call_id}",
         );
 
@@ -136,7 +139,7 @@ mod e2e {
                         assert_eq!(result, expected);
                     }
                 } else {
-                    gadget_logging::info!("No expected outputs specified, skipping signing verification");
+                    info!("No expected outputs specified, skipping signing verification");
                 }
             })
             .await


### PR DESCRIPTION
Based on the first external application of the workspace, the workspace will need the following enhancements:

* Add feature flag for `networking` under the `gadget-context-derive` crate; then enable the `networking` feature under`gadget-networking` simultaneously
* feature-gate p2p macro `#[cfg(feature = "networking")]`
* Tangle client will need to update how it returns ECDSA keys to be compatible with the `NetworkDeliveryWrapper`
* Add arbitrary hashing macro for convenience
* Add better `blueprint_test_utils` for testing