### PR TITLE
chore(deps): bump blueprint-sdk to v0.2.0-alpha.5 (crates.io)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ master_revision = "Latest"
 
 [dependencies]
 # Gadget dependencies
-blueprint-sdk = { git = "https://github.com/tangle-network/gadget-workspace/", features = ["tangle", "local-store", "macros", "networking", "round-based-compat"] }
+blueprint-sdk = { version = "0.2.0-alpha.5", features = ["tangle", "local-store", "macros", "networking", "round-based-compat"] }
 gadget-macros = { git = "https://github.com/tangle-network/gadget-workspace/" }
 color-eyre = { version = "0.6", features = ["tracing-error", "color-spantrace"] }
 hex = { version = "0.4.3", default-features = false }
@@ -28,10 +28,10 @@ frost-secp256k1-tr = { git = "https://github.com/webb-tools/tangle.git", branch 
 wsts = "3.0.0"
 
 [build-dependencies]
-blueprint-sdk = { git = "https://github.com/tangle-network/gadget-workspace/",   features = ["build"] }
+blueprint-sdk = { version = "0.2.0-alpha.5", features = ["build"] }
 
 [dev-dependencies]
-blueprint-sdk = { git = "https://github.com/tangle-network/gadget-workspace/",  features = ["testing"] }
+blueprint-sdk = { version = "0.2.0-alpha.5", features = ["testing"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Switches `blueprint-*` deps from `branch = main` git refs onto pinned crates.io versions. Picks up the audit follow-up batch (M-2 / H-1 / F-001 + governance-tunable operator cap) via tnt-core-bindings v0.17.1.

Bumps `rust-toolchain.toml` to 1.91 to match the new SDK MSRV.