### PR TITLE
chore(deps): bump tnt-core 0.1.0 → 0.13.0 + blueprint-sdk → 0.2.0-alpha.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ master_revision = "Latest"
 
 [dependencies]
 # Gadget dependencies
-blueprint-sdk = { version = "0.2.0-alpha.5", features = ["tangle", "local-store", "macros", "networking", "round-based-compat"] }
+blueprint-sdk = { version = "0.2.0-alpha.6", features = ["tangle", "local-store", "macros", "networking", "round-based-compat"] }
 gadget-macros = { git = "https://github.com/tangle-network/gadget-workspace/" }
 color-eyre = { version = "0.6", features = ["tracing-error", "color-spantrace"] }
 hex = { version = "0.4.3", default-features = false }
@@ -28,10 +28,10 @@ frost-secp256k1-tr = { git = "https://github.com/webb-tools/tangle.git", branch 
 wsts = "3.0.0"
 
 [build-dependencies]
-blueprint-sdk = { version = "0.2.0-alpha.5", features = ["build"] }
+blueprint-sdk = { version = "0.2.0-alpha.6", features = ["build"] }
 
 [dev-dependencies]
-blueprint-sdk = { version = "0.2.0-alpha.5", features = ["testing"] }
+blueprint-sdk = { version = "0.2.0-alpha.6", features = ["testing"] }
 
 [features]
 default = ["std"]

--- a/contracts/src/WstsBlueprint.sol
+++ b/contracts/src/WstsBlueprint.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSE
 pragma solidity >=0.8.13;
 
-import "dependencies/tnt-core-0.1.0/src/BlueprintServiceManagerBase.sol";
+import "tnt-core/src/BlueprintServiceManagerBase.sol";
 
 /**
  * @title WstsBlueprint

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,6 +10,9 @@ auto_detect_remappings = true
 
 [dependencies]
 forge-std = "1.9.4"
-tnt-core = "0.1.0"
+tnt-core = "0.13.0"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
+
+[soldeer]
+recursive_deps = true

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,3 @@
-forge-std-1.9.4/=dependencies/forge-std-1.9.4/src/
-tnt-core=dependencies/tnt-core-0.1.0/src/
+@openzeppelin/contracts/=dependencies/tnt-core-0.13.0/dependencies/@openzeppelin-contracts-5.1.0/
+forge-std/=dependencies/forge-std-1.9.4/src/
+tnt-core/=dependencies/tnt-core-0.13.0/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -1,0 +1,13 @@
+[[dependencies]]
+name = "forge-std"
+version = "1.9.4"
+url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_4_25-10-2024_14:36:59_forge-std-1.9.zip"
+checksum = "b5be24beb5e4dab5e42221b2ad1288b64c826bee5ee71b6159ba93ffe86f14d4"
+integrity = "3874463846ab995a6a9a88412913cacec6144f7605daa1af57c2d8bf3f210b13"
+
+[[dependencies]]
+name = "tnt-core"
+version = "0.13.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/tnt-core/0_13_0_08-05-2026_21:58:28_tnt-core.zip"
+checksum = "b800ed4ca62ef85a7db2cbfcbfb0649459c5dfe714851581ef3069cccb595391"
+integrity = "0d1d5a9a10d694db8c3dd35e7ece816427606f9d0de77ebe01e7789a3d1fd558"


### PR DESCRIPTION
Brings the Solidity + Rust dep pins in line with the deployed Tangle protocol on Base Sepolia. Larger jump than the other repos in this batch since wsts was still on tnt-core 0.1.0.

## What changed

- **`foundry.toml`**: `tnt-core = "0.1.0"` → `"0.13.0"` (latest soldeer release). Added `[soldeer] recursive_deps = true` so transitive deps (notably the nested `@openzeppelin-contracts-5.1.0` inside the tnt-core package) are unpacked on `forge soldeer update` — without this the build fails with `EnumerableSet.sol not found`.
- **`remappings.txt`**: switched from versioned key (`tnt-core-0.13.0/=`) to the unversioned `tnt-core/=` style used by the other blueprint repos; added the `@openzeppelin/contracts/=` remap pointing at the nested deps.
- **`contracts/src/WstsBlueprint.sol`**: import path switched from the hardcoded `dependencies/tnt-core-0.1.0/src/...` to the remapped `tnt-core/src/...` so future bumps don't require source edits.
- **`dependencies/tnt-core-0.1.0/`**: deleted.
- **`Cargo.toml`**: `blueprint-sdk` version pin `0.2.0-alpha.5` → `0.2.0-alpha.6`.
- **`soldeer.lock`**: regenerated.

## Why

`BlueprintServiceManagerBase` ABI evolved between tnt-core 0.1.0 and 0.13.0 — notably the `BlueprintDefinition` struct gained fields. The deployed Tangle proxy on Base Sepolia routes the 0.13.0 selector.

## Verification

- [x] `forge build` — clean (lint warning only)